### PR TITLE
Fixing is-js crashing in Node.js on a window object

### DIFF
--- a/is.js
+++ b/is.js
@@ -59,7 +59,7 @@
 			// fail fast for falsy/non-object/HTMLElement/window objects
 			// also check constructor properties - objects don't have their own constructor,
 			// and their constructor does not have its own `isPrototypeOf` function
-			if (!o || typeof o !== 'object' || is_element(o) || o === window ||
+			if (!o || typeof o !== 'object' || is_element(o) || (typeof window !== 'undefined' && o === window) ||
 			   (o.constructor && ! hasOwn.call(o, 'constructor') && ! hasOwn.call(o.constructor.prototype, 'isPrototypeOf'))
 			   ) {
 				return false;


### PR DESCRIPTION
Hey Scott. I've encountered an error when using is-js in node, it crashes when referencing window object in is_hash function ('window is not defined' error), I've implemented a fix for you, so if you could pull and update in npm I'd appreciate it. Thx
