### PR TITLE
negating all methods inside is.no object

### DIFF
--- a/is.js
+++ b/is.js
@@ -123,4 +123,21 @@
 			return !container;
 		}
 	};
+
+	// all is.js methods, will be available
+	// as is.not.method, for negating purposes
+	is.not = {};
+	// negating all methods
+	for( var fn in is ) {
+		// skipping non-functions
+		if( is.hasOwnProperty(fn) && is.fn(is[fn]) ) {
+			// create closure to keep reference
+			(function(fn) {
+				is.not[ fn ] = function() {
+					return !is[fn].apply(this, arguments);
+				}	
+			})(fn)
+		}
+	}
+
 }));


### PR DESCRIPTION
I thought it will be handy to have all those methods inside `is.not` object, and more readable..

``` js
// so instead of this
if( !is.string( obj ) ) {
}

// you can use 
if( is.not.string( obj ) ) {
}
```

 same thing applies to all methods.
